### PR TITLE
Fix the regression test for ocaml/dune#4177

### DIFF
--- a/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/run.t
@@ -16,5 +16,11 @@ to fail.
   unknown option '-option-that-is-not-accepted-by-ocaml'.
   [1]
 
-This should warn when there is a unused open module
+Do not warn when there is a unused open module in the inline tests.
+Protects against the regression reported in
+https://github.com/ocaml/dune/issues/4177
+
   $ dune runtest open_opt --root ./test-project
+  Entering directory 'test-project'
+  inline_test_runner_test_foo alias open_opt/runtest
+  unused_open_backend

--- a/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/test-project/dune
+++ b/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/test-project/dune
@@ -4,3 +4,12 @@
  (inline_tests.backend
   (generate_runner
    (echo "let () = print_endline \"backend_foo\""))))
+
+(library
+ (name unused_open_backend)
+ (modules ())
+ (inline_tests.backend
+  (generate_runner
+   (echo "
+open Char
+let () = print_endline \"unused_open_backend\""))))

--- a/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/test-project/open_opt/dune
+++ b/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/test-project/open_opt/dune
@@ -1,5 +1,4 @@
 (library
  (name test_foo)
  (inline_tests
-  (backend backend_foo)
-  (flags :standard -w -24 -g )))
+  (backend unused_open_backend)))

--- a/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/test-project/open_opt/test_foo.ml
+++ b/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/test-project/open_opt/test_foo.ml
@@ -1,1 +1,0 @@
-open Char


### PR DESCRIPTION
iiuc, this should give us a failing test (against `main`) for the the regression we're trying to address in ocaml/dune#4177.

The currently commented out lines do make this test pass, so we can see that somehow, counter-intuitively, the use of `Ocaml_flags.append_common` is messing up the flags. 